### PR TITLE
Rewrite for (str.replace x (str.replace y z w) u)

### DIFF
--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -1733,9 +1733,9 @@ Node TheoryStringsRewriter::rewriteContains( Node node ) {
       // if (str.contains x y) = false and (str.contains x w) = false
       //
       // Reasoning: (str.contains x y) checks that x does not contain y if the
-      // inner replacement does not change y. (str.contains x w) checks that if
-      // the inner replacement changes anything in y, the w makes it impossible
-      // for it to occur in x.
+      // replacement does not change y. (str.contains x w) checks that if the
+      // replacement changes anything in y, the w makes it impossible for it to
+      // occur in x.
       Node ctnUnchanged = nm->mkNode(kind::STRING_STRCTN, node[0], n[0]);
       Node ctnUnchangedR = Rewriter::rewrite(ctnUnchanged);
 

--- a/test/unit/theory/theory_strings_rewriter_white.h
+++ b/test/unit/theory/theory_strings_rewriter_white.h
@@ -322,4 +322,31 @@ class TheoryStringsRewriterWhite : public CxxTest::TestSuite
     Node res_idof_aaad = Rewriter::rewrite(idof_aaad);
     TS_ASSERT_EQUALS(res_idof_abcd, res_idof_aaad);
   }
+
+  void testRewriteReplace()
+  {
+    TypeNode strType = d_nm->stringType();
+
+    Node a = d_nm->mkConst(::CVC4::String("A"));
+    Node b = d_nm->mkConst(::CVC4::String("B"));
+    Node c = d_nm->mkConst(::CVC4::String("C"));
+    Node d = d_nm->mkConst(::CVC4::String("D"));
+    Node x = d_nm->mkVar("x", strType);
+
+    // (str.replace "A" (str.replace "B", x, "C") "D") --> "A"
+    Node repl_repl = d_nm->mkNode(kind::STRING_STRREPL,
+                                  a,
+                                  d_nm->mkNode(kind::STRING_STRREPL, b, x, c),
+                                  d);
+    Node res_repl_repl = Rewriter::rewrite(repl_repl);
+    TS_ASSERT_EQUALS(res_repl_repl, a);
+
+    // (str.replace "A" (str.replace "B", x, "A") "D") -/-> "A"
+    repl_repl = d_nm->mkNode(kind::STRING_STRREPL,
+                             a,
+                             d_nm->mkNode(kind::STRING_STRREPL, b, x, a),
+                             d);
+    res_repl_repl = Rewriter::rewrite(repl_repl);
+    TS_ASSERT_DIFFERS(res_repl_repl, a);
+  }
 };

--- a/test/unit/theory/theory_strings_rewriter_white.h
+++ b/test/unit/theory/theory_strings_rewriter_white.h
@@ -349,4 +349,25 @@ class TheoryStringsRewriterWhite : public CxxTest::TestSuite
     res_repl_repl = Rewriter::rewrite(repl_repl);
     TS_ASSERT_DIFFERS(res_repl_repl, a);
   }
+
+  void testRewriteContains()
+  {
+    TypeNode strType = d_nm->stringType();
+
+    Node a = d_nm->mkConst(::CVC4::String("A"));
+    Node b = d_nm->mkConst(::CVC4::String("B"));
+    Node c = d_nm->mkConst(::CVC4::String("C"));
+    Node f = d_nm->mkConst(false);
+    Node x = d_nm->mkVar("x", strType);
+
+    // (str.contains "A" (str.++ a (str.replace "B", x, "C")) --> false
+    Node repl_repl =
+        d_nm->mkNode(kind::STRING_STRCTN,
+                     a,
+                     d_nm->mkNode(kind::STRING_CONCAT,
+                                  a,
+                                  d_nm->mkNode(kind::STRING_STRREPL, b, x, c)));
+    Node res_repl_repl = Rewriter::rewrite(repl_repl);
+    TS_ASSERT_EQUALS(res_repl_repl, f);
+  }
 };


### PR DESCRIPTION
This commit adds the following rewrite:

(str.replace x (str.replace y z w) u) --> x
if (str.contains x y) = false and (str.contains x w) = false

Reasoning: (str.contains x y) checks that x does not contain y if the
inner replacement does not change y. (str.contains x w) checks that if
the inner replacement changes anything in y, the w makes it impossible
for it to occur in x.