### PR TITLE
model blocker with get values

### DIFF
--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1671,7 +1671,7 @@ void GetValueCommand::invoke(SmtEngine* smtEngine)
       smt::SmtScope scope(smtEngine);
       Node request = Node::fromExpr(
           options::expandDefinitions() ? smtEngine->expandDefinitions(e) : e);
-      Node value = Node::fromExpr(smtEngine->getValue(e));
+      Node value = Node::fromExpr(smtEngine->getValue(e, true));
       if (value.getType().isInteger() && request.getType() == nm->realType())
       {
         // Need to wrap in division-by-one so that output printers know this

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -25,7 +25,7 @@ namespace CVC4 {
 Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
                                    theory::TheoryModel* m,
                                    BlockModelsMode mode,
-                                   std::vector<Node> getValueNodes)
+                                   const std::vector<Node>* nodesToBlock)
 {
   NodeManager* nm = NodeManager::currentNM();
   // convert to nodes
@@ -38,7 +38,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
   Trace("model-blocker") << "Compute model blocker, assertions:" << std::endl;
   Node blocker;
   if (mode == BLOCK_MODELS_LITERALS) {
-    Assert(getValueNodes.size() == 0);
+    Assert(nodesToBlock = NULL);
     // optimization: filter to only top-level disjunctions
     unsigned counter = 0;
     std::vector<Node> asserts;
@@ -231,7 +231,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
     Assert(mode == BLOCK_MODELS_VALUES);
     std::vector<Node> blockers;
     //if specific terms were not specified in get-value, block all variables of the model
-    if (getValueNodes.size() == 0) {
+    if (nodesToBlock == NULL) {
       Trace("model-blocker") << "no get-value recognized" << std::endl;
       std::unordered_set<Node, NodeHashFunction> symbols;
       for (Node n: tlAsserts) {
@@ -248,7 +248,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
     //otherwise, block all terms that were specified in get-value
     else {
       std::unordered_set<Node, NodeHashFunction> terms;
-      for (Node n : getValueNodes) {
+      for (Node n : *nodesToBlock) {
         Node v = m->getValue(n);
         Node a = nm->mkNode(DISTINCT, n, v);
         blockers.push_back(a);

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -25,7 +25,7 @@ namespace CVC4 {
 Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
                                    theory::TheoryModel* m,
                                    BlockModelsMode mode,
-                                   const std::vector<Node>* nodesToBlock)
+                                   const std::vector<Node>& nodesToBlock)
 {
   NodeManager* nm = NodeManager::currentNM();
   // convert to nodes
@@ -38,7 +38,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
   Trace("model-blocker") << "Compute model blocker, assertions:" << std::endl;
   Node blocker;
   if (mode == BLOCK_MODELS_LITERALS) {
-    Assert(nodesToBlock = NULL);
+    Assert(nodesToBlock.empty());
     // optimization: filter to only top-level disjunctions
     unsigned counter = 0;
     std::vector<Node> asserts;
@@ -231,7 +231,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
     Assert(mode == BLOCK_MODELS_VALUES);
     std::vector<Node> blockers;
     //if specific terms were not specified in get-value, block all variables of the model
-    if (nodesToBlock == NULL) {
+    if (nodesToBlock.empty()) {
       Trace("model-blocker") << "no get-value recognized" << std::endl;
       std::unordered_set<Node, NodeHashFunction> symbols;
       for (Node n: tlAsserts) {
@@ -248,7 +248,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
     //otherwise, block all terms that were specified in get-value
     else {
       std::unordered_set<Node, NodeHashFunction> terms;
-      for (Node n : *nodesToBlock) {
+      for (Node n : nodesToBlock) {
         Node v = m->getValue(n);
         Node a = nm->mkNode(DISTINCT, n, v);
         blockers.push_back(a);

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -10,6 +10,7 @@
  ** directory for licensing information.\endverbatim
  **
  ** \brief Implementation of utility for blocking models.
+ **
  **/
 
 #include "smt/model_blocker.h"

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -22,7 +22,6 @@
 #include "expr/expr.h"
 #include "options/smt_options.h"
 #include "theory/theory_model.h"
-#include "context/cdlist_forward.h"
 
 namespace CVC4 {
 

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -38,13 +38,16 @@ class ModelBlocker
    * This returns a disjunction of literals ~L1 V ... V ~Ln with the following
    * properties:
    * (1) L1 ... Ln hold in the current model (given by argument m),
-   * (2) L1 ... Ln are literals that occur in assertions and propositionally
+   * (2) if mode is set to "literals", L1 ... Ln are literals that occur in assertions and propositionally
    * entail all non-unit top-level assertions.
+   * (3) if mode is set to "values", L1 ... Ln are literals of the form x=c, where c is the value of x in the current model.
+   * (4) if nodesToBlock is not empty, L1 ... Ln are literals of the form t=c, where t is
+   *     an element of nodesToBlock and c is its value in the current model.
    * 
    * For example, if our input is:
    *    x > 0 ^ ( y < 0 V z < 0 V w < 0 )
    * and m is { x -> 1, y -> 2, z -> -1, w -> -1 }, then this method may
-   * return ~(z < 0) or ~(w < 0).
+   * return ~(z < 0) or ~(w < 0) when set to mode "literals".
    * 
    * Notice that we do not require that L1...Ln entail unit top-level assertions
    * since these literals are trivially entailed to be true in all models of

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -31,7 +31,6 @@ namespace CVC4 {
 class ModelBlocker
 {
  
- typedef context::CDList<Node> NodeList;
 
  public:
   /** get model blocker

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -51,7 +51,7 @@ class ModelBlocker
    * our input. In other words, we do not return ~(x < 0) V ~(w < 0) since the
    * left disjunct is always false.
    */
-  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode, const std::vector<Node>* nodesToBlock = NULL);
+  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode, const std::vector<Node>& nodesToBlock = std::vector<Node>());
 }; /* class TheoryModelCoreBuilder */
 
 }  // namespace CVC4

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -52,7 +52,7 @@ class ModelBlocker
    * our input. In other words, we do not return ~(x < 0) V ~(w < 0) since the
    * left disjunct is always false.
    */
-  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode, std::vector<Node> getValueNodes);
+  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode, const std::vector<Node>* nodesToBlock = NULL);
 }; /* class TheoryModelCoreBuilder */
 
 }  // namespace CVC4

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -22,6 +22,7 @@
 #include "expr/expr.h"
 #include "options/smt_options.h"
 #include "theory/theory_model.h"
+#include "context/cdlist_forward.h"
 
 namespace CVC4 {
 
@@ -30,6 +31,9 @@ namespace CVC4 {
  */
 class ModelBlocker
 {
+ 
+ typedef context::CDList<Node> NodeList;
+
  public:
   /** get model blocker
    *
@@ -49,7 +53,7 @@ class ModelBlocker
    * our input. In other words, we do not return ~(x < 0) V ~(w < 0) since the
    * left disjunct is always false.
    */
-  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode);
+  static Expr getModelBlocker(const std::vector<Expr>& assertions, theory::TheoryModel* m, BlockModelsMode mode, std::vector<Node> getValueNodes);
 }; /* class TheoryModelCoreBuilder */
 
 }  // namespace CVC4

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4208,7 +4208,7 @@ Expr SmtEngine::getValue(const Expr& ex) const
   return resultNode.toExpr();
 }
 
-vector<Node> SmtEngine::getValues(const vector<Node> nodes) {
+vector<Node> SmtEngine::getValues(const vector<Node>& nodes) {
   vector<Node> result;
   for (Node n : nodes) {
     Node value = Node::fromExpr(getValue(n.toExpr()));
@@ -4228,7 +4228,7 @@ vector<Node> SmtEngine::getValues(const vector<Node> nodes) {
       Node eae = d_private->expandDefinitions(ea, cache);
       eassertsProc.push_back(eae.toExpr());
     }
-    Expr eblocker = ModelBlocker::getModelBlocker(eassertsProc, m, options::blockModelsMode(), &nodes);
+    Expr eblocker = ModelBlocker::getModelBlocker(eassertsProc, m, options::blockModelsMode(), nodes);
     assertFormula(eblocker);
   }
   return result;

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -185,15 +185,6 @@ class CVC4_PUBLIC SmtEngine {
    */
   smt::CommandList* d_modelCommands;
 
-
-  /**
-   * If there is a (get-value (t1 t2 ... tn)) command in the current
-   * context, then this vector includes t1,...,tn.
-   * This field is changed in getValue function, which is const, 
-   * therefore it is declared mutable.
-   */
-  mutable std::vector<Node> d_getValueNodes;
-
   /**
    * A vector of declaration commands waiting to be dumped out.
    * Once the SmtEngine is fully initialized, we'll dump them.
@@ -747,9 +738,16 @@ class CVC4_PUBLIC SmtEngine {
    * set to operate interactively and produce-models is on.
    * if isCommand == true then this call came from a get-value command
    */
-  Expr getValue(const Expr& e, bool isCommand = false) const
+  Expr getValue(const Expr& e) const
       /* throw(ModalException, TypeCheckingException, LogicException, UnsafeInterruptException) */
       ;
+
+
+  /**
+   * Same as getValue but for a vector of expressions
+   */
+  std::vector<Node> getValues(const std::vector<Node> nodes);
+
 
   /**
    * Add a function to the set of expressions whose value is to be

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -185,6 +185,15 @@ class CVC4_PUBLIC SmtEngine {
    */
   smt::CommandList* d_modelCommands;
 
+
+  /**
+   * If there is a (get-value (t1 t2 ... tn)) command in the current
+   * context, then this vector includes t1,...,tn.
+   * This field is changed in getValue function, which is const, 
+   * therefore it is declared mutable.
+   */
+  mutable std::vector<Node> d_getValueNodes;
+
   /**
    * A vector of declaration commands waiting to be dumped out.
    * Once the SmtEngine is fully initialized, we'll dump them.
@@ -736,8 +745,9 @@ class CVC4_PUBLIC SmtEngine {
    * Get the assigned value of an expr (only if immediately preceded
    * by a SAT or INVALID query).  Only permitted if the SmtEngine is
    * set to operate interactively and produce-models is on.
+   * if isCommand == true then this call came from a get-value command
    */
-  Expr getValue(const Expr& e) const
+  Expr getValue(const Expr& e, bool isCommand = false) const
       /* throw(ModalException, TypeCheckingException, LogicException, UnsafeInterruptException) */
       ;
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -745,7 +745,7 @@ class CVC4_PUBLIC SmtEngine {
   /**
    * Same as getValue but for a vector of expressions
    */
-  std::vector<Node> getValues(const std::vector<Node> nodes);
+  std::vector<Node> getValues(const std::vector<Node>& nodes);
 
 
   /**

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -736,7 +736,6 @@ class CVC4_PUBLIC SmtEngine {
    * Get the assigned value of an expr (only if immediately preceded
    * by a SAT or INVALID query).  Only permitted if the SmtEngine is
    * set to operate interactively and produce-models is on.
-   * if isCommand == true then this call came from a get-value command
    */
   Expr getValue(const Expr& e) const
       /* throw(ModalException, TypeCheckingException, LogicException, UnsafeInterruptException) */


### PR DESCRIPTION
This PR allows the user to choose which terms should be blocked in the next model, in case `--modelBlocker=values` was set.
Main changes:
1. A vector of nodes `d_getValueNodes` was added as a member to `SmtEngine`. It saves all terms whose value was asked by a `get-value` command since the last time `get-model` was called. 
2. In order to know whether SmtEngine::getValue was called by a get-value command (and not internally), a boolean flag `isCommand` was added as a parameter to it.
3. This vector `d_getValueNodes` is passed to `getModelBlocker`. If it is not empty, and we are in "values" mode, we only block the terms in this vector.

Originally I wanted to block `d_getValueNodes` from `getValues()`. However, this value is declared `const`, and blocking a model changes the state of `SmtEngine`.
This is not ideal, because it forces the user to call `(get-model)` just for blocking, while they may be interested in seeing only the values they asked for in `(get-value)`.
Also, maintaining `d_getValueNodes` is not very clean.

Suggestions are welcome.

An example input file:
```
(set-logic UFNIA)
(declare-fun a () Int)
(declare-fun b () Int)
(declare-fun f (Int) Int)

(assert (= (+ a a) b))
(assert (> (f a) (f b)))

(check-sat)
(get-value (a b (f a)))
(get-model)

(check-sat)
(get-value (a b (f a)))
(get-model)


(check-sat)
(get-value (a b (f a)))
```