### PR TITLE
Add sum lemmas 

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -636,6 +636,15 @@ header = "options/smt_options.h"
   help       = "translate bvand to its integer variant (experimental)"
 
 [[option]]
+  name       = "bvToIntIandWithSum"
+  category   = "undocumented"
+  long       = "bv-to-int-iand-with-sum"
+  type       = "bool"
+  default    = "false"
+  read_only  = true
+  help       = "Expand iand to a sum"
+
+[[option]]
   name       = "solveIntAsBV"
   category   = "undocumented"
   long       = "solve-int-as-bv=N"

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -37,7 +37,7 @@ using namespace CVC4::theory::bv;
 
 namespace {
 
-Rational intpow2(uint64_t b)
+static Rational intpow2(uint64_t b)
 {
   return Rational(Integer(2).pow(b), Integer(1));
 }
@@ -77,7 +77,8 @@ Node BVToInt::maxInt(uint64_t k)
 Node BVToInt::pow2(uint64_t k)
 {
   Assert(k >= 0);
-  return d_nm->mkConst<Rational>(intpow2(k));
+  NodeManager* nm = NodeManager::currentNM();
+  return nm->mkConst<Rational>(intpow2(k));
 }
 
 Node BVToInt::modpow2(Node n, uint64_t exponent)
@@ -869,7 +870,8 @@ Node BVToInt::createITEFromTable(
   // The table represents a function from pairs of integers to integers, where
   // all integers are between 0 (inclusive) and max_value (exclusive).
   Assert(table.size() == max_value * max_value);
-  Node ite = d_nm->mkConst<Rational>(table[std::make_pair(0, 0)]);
+  NodeManager* nm = NodeManager::currentNM();
+  Node ite = nm->mkConst<Rational>(table[std::make_pair(0, 0)]);
   for (uint64_t i = 0; i < max_value; i++)
   {
     for (uint64_t j = 0; j < max_value; j++)
@@ -878,13 +880,13 @@ Node BVToInt::createITEFromTable(
       {
         continue;
       }
-      ite = d_nm->mkNode(
+      ite = nm->mkNode(
           kind::ITE,
-          d_nm->mkNode(
+          nm->mkNode(
               kind::AND,
-              d_nm->mkNode(kind::EQUAL, x, d_nm->mkConst<Rational>(i)),
-              d_nm->mkNode(kind::EQUAL, y, d_nm->mkConst<Rational>(j))),
-          d_nm->mkConst<Rational>(table[std::make_pair(i, j)]),
+              nm->mkNode(kind::EQUAL, x, nm->mkConst<Rational>(i)),
+              nm->mkNode(kind::EQUAL, y, nm->mkConst<Rational>(j))),
+          nm->mkConst<Rational>(table[std::make_pair(i, j)]),
           ite);
     }
   }
@@ -947,7 +949,8 @@ Node BVToInt::createBitwiseNode(Node x,
    * More details are in bv_to_int.h .
    */
   uint64_t sumSize = bvsize / granularity;
-  Node sumNode = d_zero;
+  NodeManager* nm = NodeManager::currentNM();
+  Node sumNode = nm->mkConst<Rational>(0);
   /**
    * extract definition in integers is:
    * (define-fun intextract ((k Int) (i Int) (j Int) (a Int)) Int
@@ -955,19 +958,19 @@ Node BVToInt::createBitwiseNode(Node x,
    */
   for (uint64_t i = 0; i < sumSize; i++)
   {
-    Node xExtract = d_nm->mkNode(
+    Node xExtract = nm->mkNode(
         kind::INTS_MODULUS_TOTAL,
-        d_nm->mkNode(kind::INTS_DIVISION_TOTAL, x, pow2(i * granularity)),
+        nm->mkNode(kind::INTS_DIVISION_TOTAL, x, pow2(i * granularity)),
         pow2(granularity));
-    Node yExtract = d_nm->mkNode(
+    Node yExtract = nm->mkNode(
         kind::INTS_MODULUS_TOTAL,
-        d_nm->mkNode(kind::INTS_DIVISION_TOTAL, y, pow2(i * granularity)),
+        nm->mkNode(kind::INTS_DIVISION_TOTAL, y, pow2(i * granularity)),
         pow2(granularity));
     Node ite = createITEFromTable(xExtract, yExtract, granularity, table);
     sumNode =
-        d_nm->mkNode(kind::PLUS,
+        nm->mkNode(kind::PLUS,
                      sumNode,
-                     d_nm->mkNode(kind::MULT, pow2(i * granularity), ite));
+                     nm->mkNode(kind::MULT, pow2(i * granularity), ite));
   }
   return sumNode;
 }

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -76,9 +76,6 @@ class BVToInt : public PreprocessingPass
  public:
   BVToInt(PreprocessingPassContext* preprocContext);
 
- protected:
-  PreprocessingPassResult applyInternal(
-      AssertionPipeline* assertionsToPreprocess) override;
 
   /**
    * A generic function that creates a node that represents a bitwise
@@ -128,7 +125,7 @@ class BVToInt : public PreprocessingPass
    *        to the original bitwise operation.
    * @return A node that represents the operation, as described above.
    */
-  Node createBitwiseNode(Node x,
+  static Node createBitwiseNode(Node x,
                          Node y,
                          uint64_t bvsize,
                          uint64_t granularity,
@@ -146,12 +143,15 @@ class BVToInt : public PreprocessingPass
    *        integers between 0 (inclusive) and 2^{bitwidth} (exclusive).
    * @return An ite term that represents this table.
    */
-  Node createITEFromTable(
+  static Node createITEFromTable(
       Node x,
       Node y,
       uint64_t granularity,
       std::map<std::pair<uint64_t, uint64_t>, uint64_t> table);
 
+ protected:
+  PreprocessingPassResult applyInternal(
+      AssertionPipeline* assertionsToPreprocess) override;
   /**
    * A generic function that creates a logical shift node (either left or
    * right). a << b gets translated to a * 2^b mod 2^k, where k is the bit
@@ -214,7 +214,7 @@ class BVToInt : public PreprocessingPass
    * @param k A non-negative integer
    * @return A node that represents the constant 2^k
    */
-  Node pow2(uint64_t k);
+  static Node pow2(uint64_t k);
 
   /**
    * @param k A positive integer k

--- a/src/theory/arith/iand_solver.h
+++ b/src/theory/arith/iand_solver.h
@@ -89,6 +89,7 @@ class IAndSolver
   NodeSet d_initRefine;
   /** all IAND terms, for each bit-width */
   std::map<unsigned, std::vector<Node> > d_iands;
+
   /**
    * convert integer value to bitvector value of bitwidth k,
    * equivalent to Rewriter::rewrite( ((_ intToBv k) n) ).
@@ -110,6 +111,13 @@ class IAndSolver
    *     ((_ iand k) x y) = Rewriter::rewrite(((_ iand k) M(x) M(y)))
    */
   Node valueBasedLemma(Node i);
+  /**
+   * Sum-based refinement lemma for i of the form ((_ iand k) x y). Returns:
+   * i = 2^0*min(x[0],y[0])+...2^{k-1}*min(x[k-1],y[k-1])
+   * where x[i] is x div i mod 2
+   * and min is defined with an ite.
+   */
+  Node sumBasedLemma(Node i);
 }; /* class IAndSolver */
 
 }  // namespace arith

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
 ; COMMAND-LINE: --solve-bv-as-int=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat


### PR DESCRIPTION
This PR adds the following lemma scheme regarding `iand`:
If `iand(x,y) != to_int(bvand(to_bv(x),to_bv(y)))` in the current model, we add:
`iand(x,y)=Sigma_{i=0}^{k-1} (2^{i}* min(x[i],y[i]))` with:
`k` is the index of the `iand` operation
`x[i]` is `x div 2^i mod 2`
`min` is defined with an ITE.

Two comments:
1. In this PR this lemma is generated by calling a utility function from the `bv_to_int` preprocessing pass. This required making some things in that pass `static`. Not ideal for the long run. If this should be cleaned now, let's discuss what is the right design here (obviously a common utility file, but we actually need a class that has a cache etc...).
2. This uses the bv-to-int preprocessing pass from master, without any optimization to the generation of ITEs. Let me know if this needs to be changed in this branch.