### PR TITLE
Add bitwise refinement lemma option for IAND

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -636,13 +636,23 @@ header = "options/smt_options.h"
   help       = "translate bvand to its integer variant (experimental)"
 
 [[option]]
-  name       = "bvToIntIandWithSum"
+  name       = "bvToIntIandMode"
   category   = "undocumented"
-  long       = "bv-to-int-iand-with-sum"
-  type       = "bool"
-  default    = "false"
+  long       = "bv-to-int-iand-mode=mode"
+  type       = "IandMode"
+  default    = "VALUE"
   read_only  = true
-  help       = "Expand iand to a sum"
+  help       = "Set the refinement scheme for integer AND"
+  help_mode  = "Refinement modes for integer AND"
+  [[option.mode.VALUE]]
+  name = "value"
+  help = "value-based refinement"
+  [[option.mode.SUM]]
+  name = "sum"
+  help = "use sum to represent integer AND in refinement"
+  [[option.mode.BITWISE]]
+  name = "bitwise"
+  help = "use bitwise comparisons on binary representation of integer for refinement"
 
 [[option]]
   name       = "solveIntAsBV"

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -230,6 +230,16 @@ Node IAndSolver::mkINot(unsigned k, Node x) const
   return ret;
 }
 
+Node IAndSolver::iextract(unsigned i, unsigned j, Node n) const
+{
+  NodeManager* nm = NodeManager::currentNM();
+  //  ((_ extract i j) n) is n / 2^j mod 2^{i-j+1}
+  Node n2j = nm->mkNode(INTS_DIVISION, n, twoToK(j));
+  Node ret = nm->mkNode(INTS_MODULUS, n2j, twoToK(i - j + 1));
+  ret = Rewriter::rewrite(ret);
+  return ret;
+}
+
 Node IAndSolver::valueBasedLemma(Node i)
 {
   Assert(i.getKind() == IAND);

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -161,7 +161,7 @@ std::vector<Node> IAndSolver::checkFullRefine()
       }
 
       // ************* additional lemma schemas go here
-      if (options::bvToIntIandWithSum()) {
+      if (options::bvToIntIandMode() == options::IandMode::SUM) {
         Node lem = sumBasedLemma(i);
         Trace("iand-lemma") << "IAndSolver::Lemma: " << lem << " ; VALUE_REFINE"
                             << std::endl;

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -306,7 +306,7 @@ Node IAndSolver::bitwiseLemma(Node i)
   {
     if (bvAbsI.extract(j, j) != bvConcI.extract(j, j))
     {
-      // x[j] & y[j] :=> ite(x[j] == 1 ^ y[j] == 1, 1, 0)
+      // x[j] & y[j] == ite(x[j] == 1 ^ y[j] == 1, 1, 0)
       cond = nm->mkNode(AND,
                         iextract(j, j, x).eqNode(d_one),
                         iextract(j, j, y).eqNode(d_one));

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -296,16 +296,20 @@ Node IAndSolver::bitwiseLemma(Node i)
   BitVector andXY = bvX & bvY;
 
   NodeManager* nm = NodeManager::currentNM();
-  Node lem = nm->mkConst<bool>(true);
+  Node lem = d_true;
 
   // compare each bit to bvI
+  Node cond;
   Node bitIAnd;
   for (unsigned j = 0; j < k; j++)
   {
     if (bvI.extract(j, j) != andXY.extract(j, j))
     {
-      // x[j] & y[j] :=> min(x[j], y[j]) :=> x[j] * y[j]
-      bitIAnd = nm->mkNode(MULT, iextract(j, j, x), iextract(j, j, x));
+      // x[j] & y[j] :=> ite(x[j] == 1 ^ y[j] == 1, 1, 0)
+      cond = nm->mkNode(AND,
+                        iextract(j, j, x).eqNode(d_one),
+                        iextract(j, j, y).eqNode(d_one));
+      bitIAnd = nm->mkNode(ITE, cond, d_one, d_zero);
       // enforce bitwise equality
       lem = nm->mkNode(AND, lem, iextract(j, j, i).eqNode(bitIAnd));
     }

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -234,7 +234,7 @@ Node IAndSolver::iextract(unsigned i, unsigned j, Node n) const
 {
   NodeManager* nm = NodeManager::currentNM();
   //  ((_ extract i j) n) is n / 2^j mod 2^{i-j+1}
-  Node n2j = nm->mkNode(INTS_DIVISION, n, twoToK(j));
+  Node n2j = nm->mkNode(INTS_DIVISION_TOTAL, n, twoToK(j));
   Node ret = nm->mkNode(INTS_MODULUS, n2j, twoToK(i - j + 1));
   ret = Rewriter::rewrite(ret);
   return ret;

--- a/src/theory/arith/iand_solver.h
+++ b/src/theory/arith/iand_solver.h
@@ -122,6 +122,12 @@ class IAndSolver
    * and min is defined with an ite.
    */
   Node sumBasedLemma(Node i);
+  /** Bitwise refinement lemma for i of the form ((_ iand k) x y). Returns:
+   *   x[j1] = y[j1] ^ ... ^ x[jn] = y[jn]
+   *   where j1, ..., jn with n < k are the bit indices where M(x) ^ M(y)
+   *   does not match M(((_ iand k) x y))
+   */
+  Node bitwiseLemma(Node i);
 }; /* class IAndSolver */
 
 }  // namespace arith

--- a/src/theory/arith/iand_solver.h
+++ b/src/theory/arith/iand_solver.h
@@ -105,6 +105,10 @@ class IAndSolver
   Node mkIOr(unsigned k, Node x, Node y) const;
   /** make inot */
   Node mkINot(unsigned k, Node i) const;
+  /** extract from integer
+   *  ((_ extract i j) n) is n / 2^j mod 2^{i-j+1}
+   */
+  Node iextract(unsigned i, unsigned j, Node n) const;
   /**
    * Value-based refinement lemma for i of the form ((_ iand k) x y). Returns:
    *   x = M(x) ^ y = M(y) =>

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,6 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,6 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,6 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-with-sum --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; COMMAND-LINE: --solve-bv-as-int=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)


### PR DESCRIPTION
This PR would add a refinement option for IAND that checks individual bits of the bitvector representation of model values. It then adds refinement lemmas correcting those bits using an integer version of extract. This primarily a baseline for better refinement schemas. It does not currently support different granularity values, but it could be extended to support that.