### PR TITLE
Complete makeover of bv2int related options

### DIFF
--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -620,20 +620,14 @@ header = "options/smt_options.h"
 [[option]]
   name       = "solveBVAsInt"
   category   = "undocumented"
-  long       = "solve-bv-as-int"
-  type       = "bool"
-  default    = "false"
-  read_only  = true
-  help       = "attempt to solve BV formulas by translation to integer arithmetic (experimental)"
-
-[[option]]
-  name       = "solveBVAsIntMode"
-  category   = "undocumented"
-  long       = "solve-bv-as-int-mode=MODE"
+  long       = "solve-bv-as-int=MODE"
   type       = "SolveBVAsIntMode"
-  default    = "SUM"
+  default    = "OFF"
   help       = "mode for translating BVAnd to integer"
   help_mode  = "solve-bv-as-int modes."
+[[option.mode.OFF]]
+  name = "off"
+  help = "Do not translate bit-vectors to integers"
 [[option.mode.SUM]]
   name = "sum"
   help = "Generate a sum expression for each bvand instance, based on the value in --solbv-bv-as-int-granularity"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -620,25 +620,40 @@ header = "options/smt_options.h"
 [[option]]
   name       = "solveBVAsInt"
   category   = "undocumented"
-  long       = "solve-bv-as-int=N"
-  type       = "uint32_t"
-  default    = "0"
+  long       = "solve-bv-as-int"
+  type       = "bool"
+  default    = "false"
   read_only  = true
   help       = "attempt to solve BV formulas by translation to integer arithmetic (experimental)"
 
 [[option]]
-  name       = "bvToIntIand"
+  name       = "solveBVAsIntMode"
   category   = "undocumented"
-  long       = "bv-to-int-iand"
-  type       = "bool"
-  default    = "false"
-  read_only  = true
-  help       = "translate bvand to its integer variant (experimental)"
+  long       = "solve-bv-as-int-mode=MODE"
+  type       = "SolveBVAsIntMode"
+  default    = "SUM"
+  help       = "mode for translating BVAnd to integer"
+  help_mode  = "solve-bv-as-int modes."
+[[option.mode.SUM]]
+  name = "sum"
+  help = "Generate a sum expression for each bvand instance, based on the value in --solbv-bv-as-int-granularity"
+[[option.mode.IAND]]
+  name = "iand"
+  help = "Translate bvand to the iand operator, ignoring --solve-bv-as-int-granularity. Granularity for iand is set separately by --iand-granularity option (experimental)"
 
 [[option]]
-  name       = "bvToIntIandMode"
+  name       = "solveBVAsIntGranularity"
   category   = "undocumented"
-  long       = "bv-to-int-iand-mode=mode"
+  long       = "solve-bv-as-int-granularity=N"
+  type       = "uint32_t"
+  default    = "1"
+  read_only  = true
+  help       = "granularity to use in --solve-bv-as-int mode (experimental)"
+
+[[option]]
+  name       = "iandMode"
+  category   = "undocumented"
+  long       = "iand-mode=mode"
   type       = "IandMode"
   default    = "VALUE"
   read_only  = true
@@ -652,7 +667,16 @@ header = "options/smt_options.h"
   help = "use sum to represent integer AND in refinement"
   [[option.mode.BITWISE]]
   name = "bitwise"
-  help = "use bitwise comparisons on binary representation of integer for refinement"
+  help = "use bitwise comparisons on binary representation of integer for refinement (experimental)"
+
+[[option]]
+  name       = "iandGranularity"
+  category   = "undocumented"
+  long       = "iand-granularity=N"
+  type       = "uint32_t"
+  default    = "1"
+  read_only  = true
+  help       = "granularity to use when producing lemmas for iand"
 
 [[option]]
   name       = "solveIntAsBV"

--- a/src/options/smt_options.toml
+++ b/src/options/smt_options.toml
@@ -639,16 +639,16 @@ header = "options/smt_options.h"
   help = "Generate a sum expression for each bvand instance, based on the value in --solbv-bv-as-int-granularity"
 [[option.mode.IAND]]
   name = "iand"
-  help = "Translate bvand to the iand operator, ignoring --solve-bv-as-int-granularity. Granularity for iand is set separately by --iand-granularity option (experimental)"
+  help = "Translate bvand to the iand operator (experimental)"
 
 [[option]]
-  name       = "solveBVAsIntGranularity"
+  name       = "BVAndIntegerGranularity"
   category   = "undocumented"
-  long       = "solve-bv-as-int-granularity=N"
+  long       = "bvand-integer-granularity=N"
   type       = "uint32_t"
   default    = "1"
   read_only  = true
-  help       = "granularity to use in --solve-bv-as-int mode (experimental)"
+  help       = "granularity to use in --solve-bv-as-int mode and for iand operator (experimental)"
 
 [[option]]
   name       = "iandMode"
@@ -668,15 +668,6 @@ header = "options/smt_options.h"
   [[option.mode.BITWISE]]
   name = "bitwise"
   help = "use bitwise comparisons on binary representation of integer for refinement (experimental)"
-
-[[option]]
-  name       = "iandGranularity"
-  category   = "undocumented"
-  long       = "iand-granularity=N"
-  type       = "uint32_t"
-  default    = "1"
-  read_only  = true
-  help       = "granularity to use when producing lemmas for iand"
 
 [[option]]
   name       = "solveIntAsBV"

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -278,7 +278,8 @@ Node BVToInt::bvToInt(Node n)
   n = makeBinary(n);
   vector<Node> toVisit;
   toVisit.push_back(n);
-  uint64_t granularity = options::solveBVAsInt();
+  uint64_t granularity = options::solveBVAsIntGranularity();
+  Assert(0 <= granularity && granularity <= 8);
 
   while (!toVisit.empty())
   {
@@ -495,10 +496,11 @@ Node BVToInt::bvToInt(Node n)
             case kind::BITVECTOR_AND:
             {
               uint64_t bvsize = current[0].getType().getBitVectorSize();
-              if (options::bvToIntIand()) {
+              if (options::solveBVAsIntMode() == options::SolveBVAsIntMode::IAND) {
                 Node iAndOp = d_nm->mkConst(IntAnd(bvsize));
                 d_bvToIntCache[current] = d_nm->mkNode(kind::IAND, iAndOp, translated_children[0], translated_children[1]);
               } else {
+                Assert(options::solveBVAsIntMode() == options::SolveBVAsIntMode::SUM);
                 // Construct an ite, based on granularity.
                 Assert(translated_children.size() == 2);
                 Node newNode = createBitwiseNode(translated_children[0],

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -496,11 +496,11 @@ Node BVToInt::bvToInt(Node n)
             case kind::BITVECTOR_AND:
             {
               uint64_t bvsize = current[0].getType().getBitVectorSize();
-              if (options::solveBVAsIntMode() == options::SolveBVAsIntMode::IAND) {
+              if (options::solveBVAsInt() == options::SolveBVAsIntMode::IAND) {
                 Node iAndOp = d_nm->mkConst(IntAnd(bvsize));
                 d_bvToIntCache[current] = d_nm->mkNode(kind::IAND, iAndOp, translated_children[0], translated_children[1]);
               } else {
-                Assert(options::solveBVAsIntMode() == options::SolveBVAsIntMode::SUM);
+                Assert(options::solveBVAsInt() == options::SolveBVAsIntMode::SUM);
                 // Construct an ite, based on granularity.
                 Assert(translated_children.size() == 2);
                 Node newNode = createBitwiseNode(translated_children[0],

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -278,7 +278,7 @@ Node BVToInt::bvToInt(Node n)
   n = makeBinary(n);
   vector<Node> toVisit;
   toVisit.push_back(n);
-  uint64_t granularity = options::solveBVAsIntGranularity();
+  uint64_t granularity = options::BVAndIntegerGranularity();
   Assert(0 <= granularity && granularity <= 8);
 
   while (!toVisit.empty())

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -222,7 +222,7 @@ bool ProcessAssertions::apply(AssertionPipeline& assertions)
   {
     d_passes["bv-to-bool"]->apply(&assertions);
   }
-  if (options::solveBVAsInt() > 0)
+  if (options::solveBVAsInt() != options::SolveBVAsIntMode::OFF)
   {
     d_passes["bv-to-int"]->apply(&assertions);
   }

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -149,7 +149,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
     logic.lock();
   }
 
-  if (options::solveBVAsInt())
+  if (options::solveBVAsInt() != options::SolveBVAsIntMode::OFF)
   {
     // not compatible with incremental
     if (options::incrementalSolving())
@@ -406,7 +406,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
       options::preSkolemQuant.set(false);
     }
 
-    if (options::solveBVAsInt())
+    if (options::solveBVAsInt() != options::SolveBVAsIntMode::OFF)
     {
       /**
        * Operations on 1 bits are better handled as Boolean operations

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -163,7 +163,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
       throw OptionException(
           "solving bitvectors as integers is incompatible with --bool-to-bv.");
     }
-    if (options::solveBVAsIntGranularity() > 8)
+    if (options::BVAndIntegerGranularity() > 8)
     {
       /**
        * The granularity sets the size of the ITE in each element

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -149,7 +149,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
     logic.lock();
   }
 
-  if (options::solveBVAsInt() > 0)
+  if (options::solveBVAsInt())
   {
     // not compatible with incremental
     if (options::incrementalSolving())
@@ -163,7 +163,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
       throw OptionException(
           "solving bitvectors as integers is incompatible with --bool-to-bv.");
     }
-    if (options::solveBVAsInt() > 8)
+    if (options::solveBVAsIntGranularity() > 8)
     {
       /**
        * The granularity sets the size of the ITE in each element
@@ -406,7 +406,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
       options::preSkolemQuant.set(false);
     }
 
-    if (options::solveBVAsInt() > 0)
+    if (options::solveBVAsInt())
     {
       /**
        * Operations on 1 bits are better handled as Boolean operations

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -273,7 +273,7 @@ Node IAndSolver::sumBasedLemma(Node i)
   Node x = i[0];
   Node y = i[1];
   size_t bvsize = i.getOperator().getConst<IntAnd>().d_size;
-  uint64_t granularity = options::iandGranularity();
+  uint64_t granularity = options::BVAndIntegerGranularity();
   NodeManager* nm = NodeManager::currentNM();
   Node lem = nm->mkNode(EQUAL, i, CVC4::preprocessing::passes::BVToInt::createBitwiseNode(x, y, bvsize, granularity, &oneBitAnd));
   return lem;

--- a/src/theory/arith/iand_solver.cpp
+++ b/src/theory/arith/iand_solver.cpp
@@ -161,13 +161,13 @@ std::vector<Node> IAndSolver::checkFullRefine()
       }
 
       // ************* additional lemma schemas go here
-      if (options::bvToIntIandMode() == options::IandMode::SUM) {
+      if (options::iandMode() == options::IandMode::SUM) {
         Node lem = sumBasedLemma(i);
         Trace("iand-lemma")
             << "IAndSolver::Lemma: " << lem << " ; SUM_REFINE" << std::endl;
         lems.push_back(lem);
       }
-      else if (options::bvToIntIandMode() == options::IandMode::BITWISE)
+      else if (options::iandMode() == options::IandMode::BITWISE)
       {
         Node lem = bitwiseLemma(i);
         Trace("iand-lemma")
@@ -273,7 +273,7 @@ Node IAndSolver::sumBasedLemma(Node i)
   Node x = i[0];
   Node y = i[1];
   size_t bvsize = i.getOperator().getConst<IntAnd>().d_size;
-  uint64_t granularity = options::solveBVAsInt();
+  uint64_t granularity = options::iandGranularity();
   NodeManager* nm = NodeManager::currentNM();
   Node lem = nm->mkNode(EQUAL, i, CVC4::preprocessing::passes::BVToInt::createBitwiseNode(x, y, bvsize, granularity, &oneBitAnd));
   return lem;

--- a/test/regress/regress0/bv/bv_to_int1.smt2
+++ b/test/regress/regress0/bv/bv_to_int1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int1.smt2
+++ b/test/regress/regress0/bv/bv_to_int1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int1.smt2
+++ b/test/regress/regress0/bv/bv_to_int1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int2.smt2
+++ b/test/regress/regress0/bv/bv_to_int2.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=5 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int2.smt2
+++ b/test/regress/regress0/bv/bv_to_int2.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int2.smt2
+++ b/test/regress/regress0/bv/bv_to_int2.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int=5 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=5 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=5 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=4 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int=4 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE: --solve-bv-as-int=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=4 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T4_180 () (_ BitVec 32))

--- a/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T4_180 () (_ BitVec 32))

--- a/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T4_180 () (_ BitVec 32))

--- a/test/regress/regress0/bv/bv_to_int_zext.smt2
+++ b/test/regress/regress0/bv/bv_to_int_zext.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T1_31078 () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_zext.smt2
+++ b/test/regress/regress0/bv/bv_to_int_zext.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T1_31078 () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_zext.smt2
+++ b/test/regress/regress0/bv/bv_to_int_zext.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T1_31078 () (_ BitVec 8))

--- a/test/regress/regress0/bv/bvuf_to_intuf.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress0/bv/bvuf_to_intuf.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress0/bv/bvuf_to_intuf.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
@@ -1,4 +1,4 @@
-;COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
+;COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
 ;EXPECT: unsat
 
 (set-logic QF_UFBV)

--- a/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
@@ -1,4 +1,4 @@
-;COMMAND-LINE: --solve-bv-as-int=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
+;COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
 ;EXPECT: unsat
 
 (set-logic QF_UFBV)

--- a/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_smtlib.smt2
@@ -1,4 +1,4 @@
-;COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
+;COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-produce-models --no-produce-unsat-cores --no-check-proofs
 ;EXPECT: unsat
 
 (set-logic QF_UFBV)

--- a/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-sort S 0)

--- a/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-sort S 0)

--- a/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-sort S 0)

--- a/test/regress/regress1/nl/iand-native-1.smt2
+++ b/test/regress/regress1/nl/iand-native-1.smt2
@@ -1,3 +1,8 @@
+; COMMAND-LINE: --iand-mode=sum --iand-granularity=1
+; COMMAND-LINE: --iand-mode=sum --iand-granularity=2
+; COMMAND-LINE: --iand-mode=bitwise 
+; COMMAND-LINE: --iand-mode=value
+; EXPECT: sat
 (set-logic QF_NIA)
 (set-info :status sat)
 (declare-fun x () Int)

--- a/test/regress/regress2/bv_to_int_ashr.smt2
+++ b/test/regress/regress2/bv_to_int_ashr.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress2/bv_to_int_ashr.smt2
+++ b/test/regress/regress2/bv_to_int_ashr.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress2/bv_to_int_ashr.smt2
+++ b/test/regress/regress2/bv_to_int_ashr.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE: --solve-bv-as-int=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_shifts.smt2
+++ b/test/regress/regress2/bv_to_int_shifts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 64))

--- a/test/regress/regress2/bv_to_int_shifts.smt2
+++ b/test/regress/regress2/bv_to_int_shifts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 64))

--- a/test/regress/regress2/bv_to_int_shifts.smt2
+++ b/test/regress/regress2/bv_to_int_shifts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 64))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --bv-to-int-iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=1 --bv-to-int-iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --solve-bv-as-int --solve-bv-as-int-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=1 --solve-bv-as-int-mode=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE: --solve-bv-as-int --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=2 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 4))


### PR DESCRIPTION
Clear separation between iand and bv2int options.

The bv2int preprocessing pass now has the following options:
--solve-bv-as-int (Boolean, whether to turn it on)
--solve-bv-as-int-granularity (int, granularity to use when generating a sum)
--solve-bv-as-int-mode (enum {sum, iand}. If `sum` is chosen, granularity is taken from the previous option. If `iand` is chosen, granularity is ignored.)

The iand module has the following options:
--iand-mode (enum {sum, bitwise, value} that chooses which axioms will be added)
--iand-granularity (int, chooses granularity for sum lemmas)