### PR TITLE
support other logics, incremental, models

### DIFF
--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -856,22 +856,26 @@ PreprocessingPassResult BVToInt::applyInternal(
 void BVToInt::addFinalizeRangeAssertions(
     AssertionPipeline* assertionsToPreprocess)
 {
+  int indexOfLastAssertion = assertionsToPreprocess->size() - 1;
+  Node lastAssertion = (*assertionsToPreprocess)[indexOfLastAssertion];
+  Node rangeAssertions;
   vector<Node> vec_range;
   vec_range.assign(d_rangeAssertions.key_begin(), d_rangeAssertions.key_end());
   if (vec_range.size() == 1)
   {
-    assertionsToPreprocess->push_back(vec_range[0]);
-    Trace("bv-to-int-debug")
-        << "range constraints: " << vec_range[0].toString() << std::endl;
+    rangeAssertions = vec_range[0];
   }
   else if (vec_range.size() >= 2)
   {
-    Node rangeAssertions =
+    rangeAssertions =
         Rewriter::rewrite(d_nm->mkNode(kind::AND, vec_range));
-    assertionsToPreprocess->push_back(rangeAssertions);
-    Trace("bv-to-int-debug")
-        << "range constraints: " << rangeAssertions.toString() << std::endl;
   }
+  Trace("bv-to-int-debug")
+        << "range constraints: " << rangeAssertions.toString() << std::endl;
+  Node newLastAssertion = d_nm->mkNode(kind::AND, lastAssertion, rangeAssertions);  
+  newLastAssertion = Rewriter::rewrite(newLastAssertion);
+  assertionsToPreprocess->replace(indexOfLastAssertion, newLastAssertion);
+
 }
 
 Node BVToInt::createShiftNode(vector<Node> children,

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -138,8 +138,7 @@ Node BVToInt::makeBinary(Node n)
       {
         // current has children, but we do not binarize it
         NodeBuilder<> builder(k);
-        if (current.getKind() == kind::BITVECTOR_EXTRACT
-            || current.getKind() == kind::APPLY_UF || current.getKind() == kind::INT_TO_BITVECTOR)
+        if (current.getMetaKind() == kind::metakind::PARAMETERIZED)
         {
           builder << current.getOperator();
         }
@@ -241,8 +240,7 @@ Node BVToInt::eliminationPass(Node n)
           // The main operator is replaced, and the children
           // are replaced with their eliminated counterparts.
           NodeBuilder<> builder(current.getKind());
-          if (current.getKind() == kind::BITVECTOR_EXTRACT
-              || current.getKind() == kind::APPLY_UF || current.getKind() == kind::INT_TO_BITVECTOR)
+          if (current.getMetaKind() == kind::metakind::PARAMETERIZED)
           {
             builder << current.getOperator();
           }
@@ -786,8 +784,7 @@ Node BVToInt::bvToInt(Node n)
               }
 
               NodeBuilder<> builder(oldKind);
-              if (oldKind == kind::BITVECTOR_EXTRACT
-                  || oldKind == kind::APPLY_UF || oldKind == kind::INT_TO_BITVECTOR)
+              if (current.getMetaKind() == kind::metakind::PARAMETERIZED)
               {
                 builder << current.getOperator();
               }

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -858,6 +858,9 @@ void BVToInt::addFinalizeRangeAssertions(
   Node rangeAssertions;
   vector<Node> vec_range;
   vec_range.assign(d_rangeAssertions.key_begin(), d_rangeAssertions.key_end());
+  if (vec_range.size() == 0) {
+    return;
+  }
   if (vec_range.size() == 1)
   {
     rangeAssertions = vec_range[0];
@@ -869,6 +872,7 @@ void BVToInt::addFinalizeRangeAssertions(
   }
   Trace("bv-to-int-debug")
         << "range constraints: " << rangeAssertions.toString() << std::endl;
+
   Node newLastAssertion = d_nm->mkNode(kind::AND, lastAssertion, rangeAssertions);  
   newLastAssertion = Rewriter::rewrite(newLastAssertion);
   assertionsToPreprocess->replace(indexOfLastAssertion, newLastAssertion);

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -62,6 +62,9 @@
 #ifndef __CVC4__PREPROCESSING__PASSES__BV_TO_INT_H
 #define __CVC4__PREPROCESSING__PASSES__BV_TO_INT_H
 
+#include "context/cdhashmap.h"
+#include "context/cdo.h"
+#include "context/context.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "preprocessing/preprocessing_pass_context.h"
 
@@ -69,7 +72,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
-using NodeMap = std::unordered_map<Node, Node, NodeHashFunction>;
+using CDNodeMap = context::CDHashMap<Node, Node, NodeHashFunction>;
 
 class BVToInt : public PreprocessingPass
 {
@@ -245,10 +248,10 @@ class BVToInt : public PreprocessingPass
   /**
    * Caches for the different functions
    */
-  NodeMap d_binarizeCache;
-  NodeMap d_eliminationCache;
-  NodeMap d_rebuildCache;
-  NodeMap d_bvToIntCache;
+  CDNodeMap d_binarizeCache;
+  CDNodeMap d_eliminationCache;
+  CDNodeMap d_rebuildCache;
+  CDNodeMap d_bvToIntCache;
 
   /**
    * Node manager that is used throughout the pass
@@ -259,7 +262,7 @@ class BVToInt : public PreprocessingPass
    * A set of constraints of the form 0 <= x < 2^k
    * These are added for every new integer variable that we introduce.
    */
-  unordered_set<Node, NodeHashFunction> d_rangeAssertions;
+  context::CDHashSet<Node, NodeHashFunction> d_rangeAssertions;
 
   /**
    * Useful constants

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -151,7 +151,14 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
 
   if (options::solveBVAsInt() != options::SolveBVAsIntMode::OFF)
   {
-    if (options::boolToBitvector() != options::BoolToBVMode::OFF)
+    // not compatible with incremental
+    if (options::incrementalSolving())
+    {
+      throw OptionException(
+          "solving bitvectors as integers is currently not supported "
+          "when solving incrementally.");
+    }
+    else if (options::boolToBitvector() != options::BoolToBVMode::OFF)
     {
       throw OptionException(
           "solving bitvectors as integers is incompatible with --bool-to-bv.");

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -151,14 +151,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
 
   if (options::solveBVAsInt() != options::SolveBVAsIntMode::OFF)
   {
-    // not compatible with incremental
-    if (options::incrementalSolving())
-    {
-      throw OptionException(
-          "solving bitvectors as integers is currently not supported "
-          "when solving incrementally.");
-    }
-    else if (options::boolToBitvector() != options::BoolToBVMode::OFF)
+    if (options::boolToBitvector() != options::BoolToBVMode::OFF)
     {
       throw OptionException(
           "solving bitvectors as integers is incompatible with --bool-to-bv.");

--- a/test/regress/regress0/bv/bv_to_int1.smt2
+++ b/test/regress/regress0/bv/bv_to_int1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=2 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=3 --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1    --no-check-proofs 
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=2    --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=3    --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4    --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int2.smt2
+++ b/test/regress/regress0/bv/bv_to_int2.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=5 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1   
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=5   
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8   
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bitwise.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bitwise.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=5 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum     --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=5 --solve-bv-as-int=sum     --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 4))

--- a/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul1.smt2
@@ -1,6 +1,6 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4 --no-check-models  --no-check-unsat-cores
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1   
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=4   
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8   
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
+++ b/test/regress/regress0/bv/bv_to_int_bvmul2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1    --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T4_180 () (_ BitVec 32))

--- a/test/regress/regress0/bv/bv_to_int_zext.smt2
+++ b/test/regress/regress0/bv/bv_to_int_zext.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1    --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun T1_31078 () (_ BitVec 8))

--- a/test/regress/regress0/bv/bvuf_to_intuf.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1   
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-fun a () (_ BitVec 4))

--- a/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
+++ b/test/regress/regress0/bv/bvuf_to_intuf_sorts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1   
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (declare-sort S 0)

--- a/test/regress/regress1/nl/iand-native-1.smt2
+++ b/test/regress/regress1/nl/iand-native-1.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --iand-mode=sum --iand-granularity=1
-; COMMAND-LINE: --iand-mode=sum --iand-granularity=2
+; COMMAND-LINE: --iand-mode=sum --bvand-integer-granularity=1
+; COMMAND-LINE: --iand-mode=sum --bvand-integer-granularity=2
 ; COMMAND-LINE: --iand-mode=bitwise 
 ; COMMAND-LINE: --iand-mode=value
 ; EXPECT: sat

--- a/test/regress/regress2/bv_to_int_ashr.smt2
+++ b/test/regress/regress2/bv_to_int_ashr.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores --no-check-proofs 
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8 --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1    --no-check-proofs 
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=8    --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/test/regress/regress2/bv_to_int_mask_array_1.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_1.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum     --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise    --no-check-proofs
 ; EXPECT: unsat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_mask_array_2.smt2
+++ b/test/regress/regress2/bv_to_int_mask_array_2.smt2
@@ -1,7 +1,7 @@
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise    --no-check-proofs
 ; EXPECT: sat
 (set-logic ALL)
 (declare-fun A () (Array Int Int))

--- a/test/regress/regress2/bv_to_int_shifts.smt2
+++ b/test/regress/regress2/bv_to_int_shifts.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1 --no-check-models  --no-check-unsat-cores
+; COMMAND-LINE:  --solve-bv-as-int=sum --bvand-integer-granularity=1   
 ; EXPECT: sat
 (set-logic QF_BV)
 (declare-fun s () (_ BitVec 64))

--- a/test/regress/regress3/bv_to_int_and_or.smt2
+++ b/test/regress/regress3/bv_to_int_and_or.smt2
@@ -1,8 +1,8 @@
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --no-check-models  --no-check-unsat-cores --no-check-proofs
-; COMMAND-LINE:  --bvand-integer-granularity=2 --solve-bv-as-int=sum  --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=sum     --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=sum    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand --iand-mode=bitwise    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=1 --solve-bv-as-int=iand    --no-check-proofs
+; COMMAND-LINE:  --bvand-integer-granularity=2 --solve-bv-as-int=sum     --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 4))


### PR DESCRIPTION
This PR add support for models, incremental, and combination with other logics.
For the latter, this is simply done by falling back to bit-vectors using to_nat and from_nat opeartors.