### PR TITLE
Fix build issue for Clang

### DIFF
--- a/src/util/run.h
+++ b/src/util/run.h
@@ -16,6 +16,8 @@
 #ifndef CVC5__RUN_H
 #define CVC5__RUN_H
 
+#include <cvc5/cvc5_export.h>
+
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -49,7 +51,7 @@ int run(const std::string& what,
         const std::vector<std::string>& argv,
         const std::string& std_input,
         std::ostream& std_output,
-        const std::string& std_error);
+        const std::string& std_error) CVC5_EXPORT;
 
 }  // namespace cvc5
 #endif  // CVC5__RUN_H


### PR DESCRIPTION
The build was failing for Clang as "run.cpp" includes "base/check.h" which is a private library and in turn includes "cvc5_private_library.h". This makes "run.cpp" also private (mostly unintentionally?) and so we need to add the "CVC5_EXPORT" decorator to the run command to use it outside.

Note: It is still not clear why this issue is only seen with Clang and not other compilers/platforms.