### PR TITLE
Update the expected input interface to invoke oracles

### DIFF
--- a/src/parser/api/cpp/oracle_binary_caller.cpp
+++ b/src/parser/api/cpp/oracle_binary_caller.cpp
@@ -27,20 +27,18 @@ namespace cvc5 {
 std::vector<Term> OracleBinaryCaller::runOracle(const std::vector<Term>& input)
 {
   std::vector<std::string> sargs;
+
+  // Push the name of the executable binary in args list.
   sargs.push_back(d_binaryName);
 
-  std::ostringstream oss;
-  bool firstTime = true;
+  // Go over the inputs to the binary, convert them to string and
+  // add each of them to the list of args.
   for (const Term& arg : input)
   {
-    if (!firstTime)
-    {
-      oss << " ";
-    }
-    firstTime = false;
+    std::ostringstream oss;
     oss << arg;
+    sargs.push_back(oss.str());
   }
-  sargs.push_back(oss.str());
   // Trace("ajr-temp") << "Input : \"" << oss.str() << "\"" << std::endl;
 
   // Run the oracle binary for `sargs`, which indicates a list of

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -193,7 +193,13 @@ std::string shell_quote(const std::string& src)
 
   for (const char ch : src)
   {
-    if (ch == '\'') result += "'\\''";
+    if (ch == '\'') {
+      // Special handling for single quote as we need to escape it
+      // because of the surrounding single quotes.
+      result += "'\\''";
+      continue;
+    }
+
     result += ch;
   }
 


### PR DESCRIPTION
We now pass the different arguments to the executable separately.
Like:
isLessThan 1 2
anotherExecutable '"Hello World"' 2

The executables can now access the different arguments as
arg[0] (= "Hello World"), arg[1] (= 2) and so on. They need not worry about
splitting into separate parameters (as this is done while calling the executable)
and can just handle each parameter independently.

Also fixed a bug in shell_quote:
To escape a single quote inside the single quotes, we need
to replace it with "'\\''". Before this commit, we were also
adding the single quote character again after this replacement
because we were missing a continue inside the if block.