### PR TITLE
different options for mbqi fast sygus

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -206,7 +206,7 @@ name   = "Quantifiers"
   category   = "expert"
   long       = "mbqi-fast-sygus-ext-vars-grammar"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "include variables defined in terms of others in grammars for fast enumerative mbqi"
 
 [[option]]
@@ -214,7 +214,7 @@ name   = "Quantifiers"
   category   = "expert"
   long       = "mbqi-fast-sygus-free-syms-grammar"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "include free symbols from the body of the quantified formula in grammars for fast enumerative mbqi"
 
 [[option]]

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -200,6 +200,23 @@ name   = "Quantifiers"
   default    = "false"
   help       = "use fast enumeration to augment instantiations from MBQI"
 
+
+[[option]]
+  name       = "mbqiFastSygusExtVarsGrammar"
+  category   = "expert"
+  long       = "mbqi-fast-sygus-ext-vars-grammar"
+  type       = "bool"
+  default    = "false"
+  help       = "include variables defined in terms of others in grammars for fast enumerative mbqi"
+
+[[option]]
+  name       = "mbqiFastSygusFreeSymsGrammar"
+  category   = "expert"
+  long       = "mbqi-fast-sygus-free-syms-grammar"
+  type       = "bool"
+  default    = "false"
+  help       = "include free symbols from the body of the quantified formula in grammars for fast enumerative mbqi"
+
 [[option]]
   name       = "mbqiFastSygusGlobalSymGrammar"
   category   = "expert"

--- a/src/theory/quantifiers/mbqi_fast_sygus.cpp
+++ b/src/theory/quantifiers/mbqi_fast_sygus.cpp
@@ -53,9 +53,13 @@ void MVarInfo::initialize(Env& env,
     trules.insert(trules.end(), vs.begin(), vs.end());
   }
   // NOTE: get free symbols from body of quantified formula here??
-  std::unordered_set<Node> syms;
-  expr::getSymbols(q[1], syms);
-  trules.insert(trules.end(), syms.begin(), syms.end());
+  // include free symbols from body of quantified formula if applicable
+  if (env.getOptions().quantifiers.mbqiFastSygusFreeSymsGrammar)
+  {
+    std::unordered_set<Node> syms;
+    expr::getSymbols(q[1], syms);
+    trules.insert(trules.end(), syms.begin(), syms.end());
+  }
   // include the external terminal rules
   for (const Node& symbol : etrules)
   {
@@ -140,8 +144,11 @@ void MQuantInfo::initialize(Env& env, InstStrategyMbqi& parent, const Node& q)
     else
     {
       d_nindices.push_back(index);
-      // variables defined in terms of others
-      etrules.push_back(v);
+      // include variables defined in terms of others if applicable
+      if (env.getOptions().quantifiers.mbqiFastSygusExtVarsGrammar)
+      {
+        etrules.push_back(v);
+      }
     }
   }
   // include the global symbols if applicable


### PR DESCRIPTION
I have included four different options corresponding to what was added to the grammar for evaluation:
    1. mbqiFastSygus is just adding the variable of the term to instantiate
    2. mbqiFastSygusExtVarsGrammar is adding the external variables
    3. mbqiFastSygusFreeSymsGrammar is adding the free symbols
    4. mbqiFastSygusGlobalSymGrammar the global symbols