### PR TITLE
added contextual term enumerator for conjecture counterexample search

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -817,6 +817,8 @@ libcvc5_add_sources(
   theory/quantifiers/cegqi/vts_term_cache.h
   theory/quantifiers/conjecture_generator.cpp
   theory/quantifiers/conjecture_generator.h
+  theory/quantifiers/contextual_enumerator.cpp
+  theory/quantifiers/contextual_enumerator.h
   theory/quantifiers/dynamic_rewrite.cpp
   theory/quantifiers/dynamic_rewrite.h
   theory/quantifiers/ematching/candidate_generator.cpp

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -913,6 +913,37 @@ name   = "Quantifiers"
   default    = "3"
   help       = "maximum depth of terms to consider for conjectures"
 
+[[option]]
+  name       = "contextualEnumerator"
+  category   = "expert"
+  long       = "ctx-enum"
+  type       = "bool"
+  default    = "false"
+  help       = "enumerate ground terms based on current signature"
+
+[[option]]
+  name       = "contextualEnumeratorLimit"
+  category   = "expert"
+  long       = "ctx-enum-limit=N"
+  type       = "int64_t"
+  default    = "50"
+  help       = "maximum number of terms to enumerate per function symbol"
+
+[[option]]
+  name       = "contextualEnumeratorStrategy"
+  category   = "expert"
+  long       = "ctx-enum-strategy=MODE"
+  type       = "ContextualEnumeratorStrategy"
+  default    = "ENUMERATE"
+  help       = "whether to generate terms using the SyGuS term enumerator or the SyGuS sampler"
+  help_mode  = "Contextual enumerator mode."
+[[option.mode.ENUMERATE]]
+  name = "enumerate"
+  help = "Use the SyGuS Term Enumerator class to generate terms."
+[[option.mode.SAMPLE]]
+  name = "sample"
+  help = "Use the SyGuS Sampler class to generate terms."
+
 ### Synthesis options
 
 [[option]]

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -339,6 +339,8 @@ const char* toString(InferenceId i)
       return "QUANTIFIERS_CONJ_GEN_SPLIT";
     case InferenceId::QUANTIFIERS_CONJ_GEN_GT_ENUM:
       return "QUANTIFIERS_CONJ_GEN_GT_ENUM";
+    case InferenceId::QUANTIFIERS_CTX_ENUM:
+      return "QUANTIFIERS_CTX_ENUM";
     case InferenceId::QUANTIFIERS_SKOLEMIZE: return "QUANTIFIERS_SKOLEMIZE";
     case InferenceId::QUANTIFIERS_REDUCE_ALPHA_EQ:
       return "QUANTIFIERS_REDUCE_ALPHA_EQ";

--- a/src/theory/inference_id.h
+++ b/src/theory/inference_id.h
@@ -474,6 +474,7 @@ enum class InferenceId
   // enumeration of ground terms for inductive theorem proving
   QUANTIFIERS_CONJ_GEN_GT_ENUM,
   //-------------------- miscellaneous
+  QUANTIFIERS_CTX_ENUM,
   // skolemization
   QUANTIFIERS_SKOLEMIZE,
   // Q1 <=> Q2, where Q1 and Q2 are alpha equivalent

--- a/src/theory/quantifiers/contextual_enumerator.cpp
+++ b/src/theory/quantifiers/contextual_enumerator.cpp
@@ -1,0 +1,485 @@
+#include "theory/quantifiers/contextual_enumerator.h"
+
+#include "expr/skolem_manager.h"
+#include "expr/sygus_grammar.h"
+#include "expr/sygus_term_enumerator.h"
+#include "theory/quantifiers/ematching/trigger_term_info.h"
+#include "theory/quantifiers/sygus/sygus_enumerator.h"
+#include "theory/quantifiers/sygus/sygus_grammar_cons.h"
+#include "theory/quantifiers/sygus_sampler.h"
+#include "util/random.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace quantifiers {
+
+ContextualEnumerator::ContextualEnumerator(Env& env,
+                                           QuantifiersState& qs,
+                                           QuantifiersInferenceManager& qim,
+                                           QuantifiersRegistry& qr,
+                                           TermRegistry& tr)
+    : QuantifiersModule(env, qs, qim, qr, tr)
+{
+}
+
+ContextualEnumerator::~ContextualEnumerator() {}
+
+bool ContextualEnumerator::needsCheck(Theory::Effort e)
+{
+  return d_qstate.getInstWhenNeedsCheck(e);
+}
+
+void ContextualEnumerator::reset_round(Theory::Effort e) {}
+
+void ContextualEnumerator::check(Theory::Effort e, QEffort quant_e)
+{
+  if (quant_e == QEFFORT_STANDARD)
+  {
+    // We want to enumerate terms for the operators op_0, ..., op_n and
+    // enum_queue is op_0(...), ..., op_n(...).
+    std::vector<Node> enum_queue = collectSignatureInformation();
+
+    if (TraceIsOn("ctx-enum-queue"))
+    {
+      debugPrintEnumQueue(enum_queue);
+    }
+
+    enumerateUf(enum_queue);
+  }
+}
+
+std::string ContextualEnumerator::identify() const
+{
+  return "contextual-enumerator";
+}
+
+std::vector<Node> ContextualEnumerator::collectSignatureInformation()
+{
+  TermDb* const term_db = getTermDatabase();
+
+  std::vector<Node> enum_queue;
+
+  // The number of function symbols in the current signature.
+  const size_t num_ops = term_db->getNumOperators();
+
+  for (size_t i = 0; i < num_ops; i++)
+  {
+    // The i th function symbol in the current signature.
+    const Node& op = term_db->getOperator(i);
+
+    // The list of ground terms with 'op' as the root function symbol.
+    DbList* const db_list = term_db->getOrMkDbListForOp(op);
+
+    if (!db_list->d_list.empty())
+    {
+      // An arbitrary ground term with root function symbol 'op'.
+      const Node& op_term = db_list->d_list[0];
+
+      if (isHandledTerm(op_term) && op_term.getKind() != Kind::APPLY_SELECTOR
+          && !op_term.getType().isBoolean())
+      {
+        if (d_uf_enum.find(op) == d_uf_enum.end())
+        {
+          if (TraceIsOn("ctx-enum-queue"))
+          {
+            Trace("ctx-enum-queue") << "Tried to find " << op << " in "
+                                    << " d_uf_enum but failed." << std::endl;
+            Trace("ctx-enum-queue") << "d_uf_enum is {";
+            for (std::unordered_set<Node>::iterator j = d_uf_enum.begin();
+                 j != d_uf_enum.end();
+                 j++)
+            {
+              Trace("ctx-enum-queue") << " " << *j;
+            }
+            Trace("ctx-enum-queue") << " }" << std::endl;
+          }
+
+          enum_queue.push_back(op_term);
+        }
+      }
+    }
+  }
+
+  return enum_queue;
+}
+
+void ContextualEnumerator::enumerateUf(const std::vector<Node>& enum_queue)
+{
+  for (const Node& queued_term : enum_queue)
+  {
+    if (d_uf_enum.find(queued_term) == d_uf_enum.end())
+    {
+      const Node& op = queued_term.getOperator();
+
+      d_uf_enum.insert(op);
+
+      // We will submit one enumeration lemma for each element in the vector
+      // enum_terms.
+
+      const Node& pred = getPredicateForType(queued_term.getType());
+
+      const std::vector<Node>& gend_terms =
+          enumerateTermsWithSygus(queued_term);
+
+      if (TraceIsOn("ctx-enum-generated"))
+      {
+        Trace("ctx-enum-generated")
+            << "Terms generated for " << op << ":" << std::endl;
+
+        for (const Node& term : gend_terms)
+        {
+          Trace("ctx-enum-generated") << "* " << term << std::endl;
+        }
+      }
+
+      for (const Node& term : gend_terms)
+      {
+        const Node& lem = nodeManager()->mkNode(Kind::APPLY_UF, pred, term);
+
+        d_qim.addPendingLemma(lem, InferenceId::QUANTIFIERS_CTX_ENUM);
+      }
+
+      d_hasAddedLemma = true;
+    }
+  }
+}
+
+bool ContextualEnumerator::isHandledTerm(const TNode n)
+{
+  return getTermDatabase()->isTermActive(n)
+         && inst::TriggerTermInfo::isAtomicTrigger(n)
+         && (n.getKind() != Kind::APPLY_UF
+             || n.getOperator().getKind() != Kind::SKOLEM);
+}
+
+Node ContextualEnumerator::getPredicateForType(TypeNode typ)
+{
+  auto it = d_typ_pred.find(typ);
+
+  if (it != d_typ_pred.end())
+  {
+    return it->second;
+  }
+  else
+  {
+    NodeManager* node_mgr = nodeManager();
+
+    TypeNode pred_typ = node_mgr->mkFunctionType(typ, node_mgr->booleanType());
+
+    Node pred = NodeManager::mkDummySkolem(
+        "PE",
+        pred_typ,
+        "was created by the contextual ground term enumerator.");
+
+    d_typ_pred[typ] = pred;
+
+    return pred;
+  }
+}
+
+std::vector<Node> ContextualEnumerator::enumerateTermsWithSygus(TNode root_term)
+{
+  // Suppose we have a function symbol 'f' with argument types 'T', 'U' and
+  // result type 'V'.  We intend to construct a grammar that enumerates
+  // f-applications.  The grammar's root non-terminal should be:
+  //
+  //     N_V ::= f(N_T, N_U)
+  //
+  // Here 'N_V', 'N_T', and 'N_U' are a non-terminals of type V, T, and U
+  // respectively.  We'll use methods from the SygusGrammarCons class to create
+  // grammars for T and U.  Cache the grammar for each argument type.  Don't
+  // worry about any further sharing since it's probably an excessive
+  // optimization.
+
+  // Prepare the map from argument types to their grammars.
+
+  std::map<TypeNode, SygusGrammar> arg_typ_to_gr;
+
+  for (auto arg : root_term)
+  {
+    TypeNode typ = arg.getType();
+
+    if (arg_typ_to_gr.find(typ) == arg_typ_to_gr.end())
+    {
+      arg_typ_to_gr.emplace(std::make_pair(
+          typ, SygusGrammarCons::mkDefaultGrammar(d_env, typ, Node::null())));
+    }
+  }
+
+  // We'll transform all argument grammars in the following manner.
+  //
+  // 1.  For all datatype-sorted non-terminals remove any rule with kind ITE or
+  // APPLY_SELECTOR.
+  //
+  // 2.  For all other non-terminals remove all rules and replace with the 'any
+  // constant' rule.
+
+  for (std::map<TypeNode, SygusGrammar>::iterator typ_gr_pair =
+           arg_typ_to_gr.begin();
+       typ_gr_pair != arg_typ_to_gr.end();
+       typ_gr_pair++)
+  {
+    SygusGrammar& gr = typ_gr_pair->second;
+
+    // Collect all the rules that we need to remove from the grammar.
+
+    std::vector<std::pair<Node, Node>> rules_to_remove;
+
+    for (const Node& nt : gr.getNtSyms())
+    {
+      for (const Node& rule : gr.getRulesFor(nt))
+      {
+        if (nt.getType().isDatatype())
+        {
+          if (rule.getKind() == Kind::ITE
+              || rule.getKind() == Kind::APPLY_SELECTOR)
+          {
+            rules_to_remove.emplace_back(std::pair<Node, Node>{nt, rule});
+          }
+        }
+        else
+        {
+          rules_to_remove.emplace_back(std::pair<Node, Node>{nt, rule});
+        }
+      }
+    }
+
+    // Remove all the rules as intended.
+
+    for (std::vector<std::pair<Node, Node>>::iterator nt_rule_pair =
+             rules_to_remove.begin();
+         nt_rule_pair != rules_to_remove.end();
+         nt_rule_pair++)
+    {
+      gr.removeRule(nt_rule_pair->first, nt_rule_pair->second);
+    }
+
+    // Add 'any constant' rules for non-terminals that have types that are not
+    // inductive datatypes.
+
+    for (const Node& nt : gr.getNtSyms())
+    {
+      const TypeNode& typ = nt.getType();
+
+      if (!typ.isDatatype())
+      {
+        gr.addAnyConstant(nt, typ);
+      }
+    }
+  }
+
+  // Isolate the root non-terminal for each argument's grammar.  For example, I
+  // expect type T's grammar to have exactly one non-terminal of type T.  This
+  // non-terminal is treated as the start non-terminal.
+
+  std::map<TypeNode, Node> arg_typ_to_nt;
+
+  for (auto entry : arg_typ_to_gr)
+  {
+    TypeNode arg_typ = entry.first;
+
+    for (auto nt : entry.second.getNtSyms())
+    {
+      if (nt.getType() == arg_typ)
+      {
+        arg_typ_to_nt[arg_typ] = nt;
+
+        break;
+      }
+    }
+  }
+
+  // Manufacture the "root" non-terminal -- the one responsible for producing
+  // all f-applications.
+
+  Node root_nt = nodeManager()->getSkolemManager()->mkDummySkolem(
+      "root_nt", root_term.getType());
+
+  // Collect all the non-terminals -- all non-terminals across all argument
+  // grammars as well as the non-terminal for the f-applications.  (Lead with
+  // the non-terminal for f-applications!)
+
+  std::vector<Node> all_nts{root_nt};
+
+  for (auto entry : arg_typ_to_gr)
+  {
+    std::vector<Node> arg_gr_nts = entry.second.getNtSyms();
+    all_nts.insert(all_nts.end(), arg_gr_nts.begin(), arg_gr_nts.end());
+  }
+
+  // Use the master list of non-terminals to construct the root grammar.
+
+  SygusGrammar root_gr(std::vector<Node>{}, all_nts);
+
+  // Make the sole production rule for the root non-terminal.
+
+  std::vector<Node> root_rule_args{root_term.getOperator()};
+
+  for (auto arg : root_term)
+  {
+    root_rule_args.push_back(arg_typ_to_nt[arg.getType()]);
+  }
+
+  Node root_rule = nodeManager()->mkNode(root_term.getKind(), root_rule_args);
+
+  // Associate root_rule with root_nt in root_gr.
+
+  root_gr.addRule(root_nt, root_rule);
+
+  // Add all rules for all non-terminals across all argument grammars to the
+  // root grammar.
+
+  for (auto entry : arg_typ_to_gr)
+  {
+    SygusGrammar gr = entry.second;
+
+    for (auto nt : gr.getNtSyms())
+    {
+      for (auto rule : gr.getRulesFor(nt))
+      {
+        root_gr.addRule(nt, rule);
+      }
+    }
+  }
+
+  // Before we resolve the grammar let's make sure we have exactly what we need
+  // by printing all its non-terminals and associated rules.
+
+  if (TraceIsOn("ctx-enum-grammar"))
+  {
+    Trace("ctx-enum-grammar")
+        << "Here are rules for each non-terminal." << std::endl;
+    for (auto nt : root_gr.getNtSyms())
+    {
+      Trace("ctx-enum-grammar") << "* " << nt << ":" << std::endl;
+      for (auto rule : root_gr.getRulesFor(nt))
+      {
+        Trace("ctx-enum-grammar") << "  * " << rule << std::endl;
+      }
+    }
+  }
+
+  // We need to resolve the grammar, quitting early if resolution fails.
+
+  const TypeNode& root_gr_typ = root_gr.resolve();
+
+  Assert(root_gr.isResolved());
+
+  // Declare the vector that we'll use to store the terms we generate.  Let's
+  // also pre-emptively grab the maxium number of terms we will generate for
+  // each function symbol.
+
+  std::vector<Node> gend_terms;
+
+  const int64_t limit = options().quantifiers.contextualEnumeratorLimit;
+
+  // Make an enumeration type to store our preference among the
+  // SygusTermEnumerator and the SygusSampler.
+
+  switch (options().quantifiers.contextualEnumeratorStrategy)
+  {
+    case options::ContextualEnumeratorStrategy::ENUMERATE:
+    {
+      SygusTermEnumerator root_gr_enum(d_env, root_gr_typ);
+
+      // Let's keep going till either increment() returns false or we generate
+      // contextualEnumeratorLimit-many terms.
+
+      int64_t n_gend_terms = 0;
+
+      // **Note**.  first_time should be false when n_gend_terms >= limit and
+      // true otherwise.
+
+      bool first_time = n_gend_terms < limit;
+
+      while (first_time || (n_gend_terms < limit && root_gr_enum.increment()))
+      {
+        if (first_time)
+        {
+          first_time = false;
+        }
+
+        const Node& curr_term = root_gr_enum.getCurrent();
+
+        if (!curr_term.isNull())
+        {
+          gend_terms.push_back(curr_term);
+
+          n_gend_terms++;
+        }
+      }
+
+      break;
+    }
+
+    case options::ContextualEnumeratorStrategy::SAMPLE:
+    {
+      // To start with we construct and initialize the sampler.
+
+      SygusSampler root_gr_sampler = SygusSampler(d_env);
+
+      const Node& root_gr_var =
+          nodeManager()->getSkolemManager()->mkDummySkolem("sampler_",
+                                                           root_gr_typ);
+
+      root_gr_sampler.initialize(
+          root_gr_typ, std::vector<Node>{root_gr_var}, limit);
+
+      // We *requested* limit-many points but actually generated
+      // n_sample_pts-many points.
+
+      const size_t n_sample_pts = root_gr_sampler.getNumSamplePoints();
+
+      Trace("ctx-enum-sampler")
+          << "Actually generated " << n_sample_pts << " points." << std::endl;
+
+      for (size_t i = 0; i < n_sample_pts; i++)
+      {
+        const std::vector<Node>& sample_pt = root_gr_sampler.getSamplePoint(i);
+
+        // We've requested only one term because the vector we passed to
+        // initialize has length exactly 1.  We'll error out if we have any more
+        // or any less terms.
+
+        Assert(sample_pt.size() == 1);
+
+        // At this point we're sure that sample_pt contains exactly one term.
+        // This is a SyGuS term.  However we want the term it represents,
+        // otherwise known as a builtin term.
+
+        gend_terms.push_back(d_treg.getTermDatabaseSygus()->sygusToBuiltin(
+            sample_pt.back(), root_gr_typ));
+      }
+
+      break;
+    }
+  }
+
+  // Let's return the terms that we have generated using the grammar.
+
+  return gend_terms;
+}
+
+void ContextualEnumerator::debugPrintEnumQueue(
+    const std::vector<Node>& enum_queue)
+{
+  Trace("ctx-enum-queue") << "enum_queue = [";
+  bool first_time = true;
+  for (auto term : enum_queue)
+  {
+    if (first_time)
+    {
+      first_time = false;
+    }
+    else
+    {
+      Trace("ctx-enum-queue") << ", ";
+    }
+    Trace("ctx-enum-queue") << term.getOperator();
+  }
+  Trace("ctx-enum-queue") << "]" << std::endl;
+}
+
+}  // namespace quantifiers
+}  // namespace theory
+}  // namespace cvc5::internal

--- a/src/theory/quantifiers/contextual_enumerator.h
+++ b/src/theory/quantifiers/contextual_enumerator.h
@@ -1,0 +1,44 @@
+#include "cvc5_private.h"
+
+#ifndef CVC5__THEORY__QUANTIFIERS__CONTEXTUAL_ENUMERATOR_H
+#define CVC5__THEORY__QUANTIFIERS__CONTEXTUAL_ENUMERATOR_H
+
+#include "smt/env_obj.h"
+#include "theory/quantifiers/quant_module.h"
+
+namespace cvc5::internal {
+namespace theory {
+namespace quantifiers {
+
+class ContextualEnumerator : public QuantifiersModule
+{
+ private:
+  bool d_hasAddedLemma;
+  std::unordered_set<Node> d_uf_enum;
+  std::map<TypeNode, Node> d_typ_pred;
+
+  std::vector<Node> collectSignatureInformation();
+  void enumerateUf(const std::vector<Node>& enum_queue);
+  std::vector<Node> enumerateTermsWithSygus(TNode term);
+  bool isHandledTerm(const TNode n);
+  Node getPredicateForType(TypeNode tn);
+  void debugPrintEnumQueue(const std::vector<Node>& enum_queue);
+
+ public:
+  ContextualEnumerator(Env& env,
+                       QuantifiersState& qs,
+                       QuantifiersInferenceManager& qim,
+                       QuantifiersRegistry& qr,
+                       TermRegistry& tr);
+  ~ContextualEnumerator();
+  bool needsCheck(Theory::Effort e) override;
+  void reset_round(Theory::Effort e) override;
+  void check(Theory::Effort e, QEffort quant_e) override;
+  std::string identify() const override;
+};
+
+}  // namespace quantifiers
+}  // namespace theory
+}  // namespace cvc5::internal
+
+#endif /* CVC5__THEORY__QUANTIFIERS__CONTEXTUAL_ENUMERATOR_H */

--- a/src/theory/quantifiers/quantifiers_modules.cpp
+++ b/src/theory/quantifiers/quantifiers_modules.cpp
@@ -66,6 +66,11 @@ void QuantifiersModules::initialize(Env& env,
     d_sg_gen.reset(new ConjectureGenerator(env, qs, qim, qr, tr));
     modules.push_back(d_sg_gen.get());
   }
+  if (options.quantifiers.contextualEnumerator)
+  {
+    d_ctx_enum.reset(new ContextualEnumerator(env, qs, qim, qr, tr));
+    modules.push_back(d_ctx_enum.get());
+  }  
   if (options.quantifiers.eMatching)
   {
     d_inst_engine.reset(new InstantiationEngine(env, qs, qim, qr, tr));

--- a/src/theory/quantifiers/quantifiers_modules.h
+++ b/src/theory/quantifiers/quantifiers_modules.h
@@ -20,6 +20,7 @@
 
 #include "theory/quantifiers/alpha_equivalence.h"
 #include "theory/quantifiers/conjecture_generator.h"
+#include "theory/quantifiers/contextual_enumerator.h"
 #include "theory/quantifiers/ematching/instantiation_engine.h"
 #include "theory/quantifiers/fmf/bounded_integers.h"
 #include "theory/quantifiers/fmf/full_model_check.h"
@@ -88,6 +89,8 @@ class QuantifiersModules
   std::unique_ptr<InstStrategySubConflict> d_issc;
   /** subgoal generator */
   std::unique_ptr<ConjectureGenerator> d_sg_gen;
+  /** signature-based ground term enumerator */
+  std::unique_ptr<ContextualEnumerator> d_ctx_enum;
   /** ceg instantiation */
   std::unique_ptr<SynthEngine> d_synth_e;
   /** full saturation */


### PR DESCRIPTION
The options associated with this quantifiers module are

- `--[no-]ctx-enum`, whether or not this module is enabled.
- `--ctx-enum-limit=N`, the maximum number of terms to generate per function symbol.
- `--ctx-enum-strategy=[enumerate|sample]`, whether the SygusTermEnumerator or the SygusSampler is used to generate new terms.

Note that changing the limit impacts the number of terms generated by the SygusTermEnumerator but not the SygusSampler.